### PR TITLE
Swift5 migration

### DIFF
--- a/EssentialFeed/Feed API/FeedItemsMapper.swift
+++ b/EssentialFeed/Feed API/FeedItemsMapper.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-internal final class FeedItemsMapper {
+ final class FeedItemsMapper {
   
   private struct Root: Decodable {
     let items: [RemoteFeedItem]
@@ -15,7 +15,7 @@ internal final class FeedItemsMapper {
   
   private static var OK_200: Int { return 200 }
   
-  internal static func map(_ data: Data, from response: HTTPURLResponse) throws -> [RemoteFeedItem] {
+   static func map(_ data: Data, from response: HTTPURLResponse) throws -> [RemoteFeedItem] {
     guard response.statusCode == OK_200, let root = try? JSONDecoder().decode(Root.self, from: data) else {
       throw RemoteFeedLoader.Error.invalidData
     }

--- a/EssentialFeed/Feed API/HTTPClient.swift
+++ b/EssentialFeed/Feed API/HTTPClient.swift
@@ -7,13 +7,10 @@
 
 import Foundation
 
-public enum HTTPClientResult {
-  case success(Data, HTTPURLResponse)
-  case failure(Error)
-}
-
 public protocol HTTPClient {
+  typealias Result = Swift.Result<(Data, HTTPURLResponse),Error>
+  
   /// The completion handler can be invoked in any thread.
   /// Clients are responsible to dispatch to appropriate threads, if needed.
-  func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void)
+  func get(from url: URL, completion: @escaping (Result) -> Void)
 }

--- a/EssentialFeed/Feed API/RemoteFeedItem.swift
+++ b/EssentialFeed/Feed API/RemoteFeedItem.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-internal struct RemoteFeedItem: Decodable {
-  internal let id: UUID
-  internal let description: String?
-  internal let location: String?
-  internal let image: URL
+ struct RemoteFeedItem: Decodable {
+   let id: UUID
+   let description: String?
+   let location: String?
+   let image: URL
 }

--- a/EssentialFeed/Feed API/RemoteFeedLoader.swift
+++ b/EssentialFeed/Feed API/RemoteFeedLoader.swift
@@ -17,7 +17,7 @@ public final class RemoteFeedLoader: FeedLoader {
     case invalidData
   }
   
-  public typealias Result = LoadFeedResult
+  public typealias Result = FeedLoader.Result
   
   public init(url: URL, client: HTTPClient) {
     self.url = url

--- a/EssentialFeed/Feed API/RemoteFeedLoader.swift
+++ b/EssentialFeed/Feed API/RemoteFeedLoader.swift
@@ -29,7 +29,7 @@ public final class RemoteFeedLoader: FeedLoader {
       guard self != nil else { return }
       
       switch result {
-      case let .success(data, response):
+      case let .success((data, response)):
         completion(RemoteFeedLoader.map(data, from: response))
    
       case .failure:

--- a/EssentialFeed/Feed API/URLSessionHTTPClient.swift
+++ b/EssentialFeed/Feed API/URLSessionHTTPClient.swift
@@ -16,12 +16,12 @@ public class URLSessionHTTPClient: HTTPClient {
   
   private struct UnexpectedValuesRepresentation: Error {}
   
-  public func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void) {
+  public func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
     session.dataTask(with: url) { data, response, error in
       if let error = error {
         completion(.failure(error))
       } else if let data = data, let response = response as? HTTPURLResponse {
-        completion(.success(data, response))
+        completion(.success((data, response)))
       }else {
         completion(.failure(UnexpectedValuesRepresentation()))
       }

--- a/EssentialFeed/Feed API/URLSessionHTTPClient.swift
+++ b/EssentialFeed/Feed API/URLSessionHTTPClient.swift
@@ -18,13 +18,15 @@ public class URLSessionHTTPClient: HTTPClient {
   
   public func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
     session.dataTask(with: url) { data, response, error in
-      if let error = error {
-        completion(.failure(error))
-      } else if let data = data, let response = response as? HTTPURLResponse {
-        completion(.success((data, response)))
-      }else {
-        completion(.failure(UnexpectedValuesRepresentation()))
-      }
+      completion(Result {
+        if let error = error {
+          throw error
+        } else if let data = data, let response = response as? HTTPURLResponse {
+          return (data, response)
+        } else {
+          throw UnexpectedValuesRepresentation()
+        }
+      })
     }.resume()
   }
 }

--- a/EssentialFeed/Feed Cache/FeedCachePolicy.swift
+++ b/EssentialFeed/Feed Cache/FeedCachePolicy.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-internal struct FeedCachePolicy {
+ struct FeedCachePolicy {
   private init() {}
   
   private static let calendar = Calendar(identifier: .gregorian)
@@ -16,7 +16,7 @@ internal struct FeedCachePolicy {
     return 7
   }
   
-  internal static func validate(_ timestamp: Date, against date: Date) -> Bool {
+   static func validate(_ timestamp: Date, against date: Date) -> Bool {
     guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
       return false
     }

--- a/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/Feed Cache/FeedStore.swift
@@ -10,10 +10,10 @@ import Foundation
 public typealias CacheFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
-  typealias DeletionResult = Error?
+  typealias DeletionResult = Result<Void,Error>
   typealias DeletionCompletion = (DeletionResult) -> Void
   
-  typealias InsertionResult = Error?
+  typealias InsertionResult = Result<Void,Error>
   typealias InsertionCompletion = (InsertionResult) -> Void
   
   typealias RetrievalResult = Result<CacheFeed?,Error>

--- a/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/Feed Cache/FeedStore.swift
@@ -10,9 +10,11 @@ import Foundation
 public typealias CacheFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
+  typealias DeletionResult = Error?
+  typealias DeletionCompletion = (DeletionResult) -> Void
   
-  typealias DeletionCompletion = (Error?) -> Void
-  typealias InsertionCompletion = (Error?) -> Void
+  typealias InsertionResult = Error?
+  typealias InsertionCompletion = (InsertionResult) -> Void
   
   typealias RetrievalResult = Result<CacheFeed?,Error>
   typealias RetrievalCompletion = (RetrievalResult) -> Void

--- a/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/Feed Cache/FeedStore.swift
@@ -7,17 +7,14 @@
 
 import Foundation
 
-public enum CacheFeed {
-  case empty
-  case found(feed: [LocalFeedImage], timestamp: Date)
-}
+public typealias CacheFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
   
   typealias DeletionCompletion = (Error?) -> Void
   typealias InsertionCompletion = (Error?) -> Void
   
-  typealias RetrievalResult = Result<CacheFeed,Error>
+  typealias RetrievalResult = Result<CacheFeed?,Error>
   typealias RetrievalCompletion = (RetrievalResult) -> Void
   
   /// The completion handler can be invoked in any thread.

--- a/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/Feed Cache/FeedStore.swift
@@ -7,17 +7,18 @@
 
 import Foundation
 
-public enum RetrieveCachedFeedResult {
+public enum CacheFeed {
   case empty
   case found(feed: [LocalFeedImage], timestamp: Date)
-  case failure(Error)
 }
 
 public protocol FeedStore {
   
   typealias DeletionCompletion = (Error?) -> Void
   typealias InsertionCompletion = (Error?) -> Void
-  typealias RetrievalCompletion = (RetrieveCachedFeedResult) -> Void
+  
+  typealias RetrievalResult = Result<CacheFeed,Error>
+  typealias RetrievalCompletion = (RetrievalResult) -> Void
   
   /// The completion handler can be invoked in any thread.
   /// Clients are responsible to dispatch to appropriate threads, if needed.

--- a/EssentialFeed/Feed Cache/Infrastructure/Codable/CodableFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/Codable/CodableFeedStore.swift
@@ -47,13 +47,13 @@ public final class CodableFeedStore: FeedStore {
     let storeURL = self.storeURL
     queue.async {
       guard let data = try? Data(contentsOf: storeURL) else {
-        return completion(.empty)
+        return completion(.success(.empty))
       }
       
       do {
         let decoder = JSONDecoder()
         let cache = try decoder.decode(Cache.self, from: data)
-        completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
+        completion(.success(.found(feed: cache.localFeed, timestamp: cache.timestamp)))
       } catch {
         completion(.failure(error))
       }

--- a/EssentialFeed/Feed Cache/Infrastructure/Codable/CodableFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/Codable/CodableFeedStore.swift
@@ -68,9 +68,9 @@ public final class CodableFeedStore: FeedStore {
         let cache = Cache(feed: feed.map(CodableFeedImage.init), timestamp: timestamp)
         let encoded = try encoder.encode(cache)
         try encoded.write(to: storeURL)
-        completion(nil)
+        completion(.success(()))
       } catch {
-        completion(error)
+        completion(.failure(error))
       }
     }
   }
@@ -79,14 +79,14 @@ public final class CodableFeedStore: FeedStore {
     let storeURL = self.storeURL
     queue.async(flags: .barrier) {
       guard FileManager.default.fileExists(atPath: storeURL.path) else {
-        return completion(nil)
+        return completion(.success(()))
       }
       
       do {
         try FileManager.default.removeItem(at: storeURL)
-        completion(nil)
+        completion(.success(()))
       } catch {
-        completion(error)
+        completion(.failure(error))
       }
     }
   }

--- a/EssentialFeed/Feed Cache/Infrastructure/Codable/CodableFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/Codable/CodableFeedStore.swift
@@ -47,13 +47,13 @@ public final class CodableFeedStore: FeedStore {
     let storeURL = self.storeURL
     queue.async {
       guard let data = try? Data(contentsOf: storeURL) else {
-        return completion(.success(.empty))
+        return completion(.success(.none))
       }
       
       do {
         let decoder = JSONDecoder()
         let cache = try decoder.decode(Cache.self, from: data)
-        completion(.success(.found(feed: cache.localFeed, timestamp: cache.timestamp)))
+        completion(.success(CacheFeed(feed: cache.localFeed, timestamp: cache.timestamp)))
       } catch {
         completion(.failure(error))
       }

--- a/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -21,9 +21,9 @@ public final class CoreDataFeedStore: FeedStore {
     perform { context in
       do {
         if let cache = try ManagedCache.find(in: context) {
-          completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
+          completion(.success(.found(feed: cache.localFeed, timestamp: cache.timestamp)))
         } else {
-          completion(.empty)
+          completion(.success(.empty))
         }
       } catch {
         completion(.failure(error))

--- a/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -19,41 +19,30 @@ public final class CoreDataFeedStore: FeedStore {
   
   public func retrieve(completion: @escaping RetrievalCompletion) {
     perform { context in
-      do {
-        if let cache = try ManagedCache.find(in: context) {
-          completion(.success(CacheFeed(feed: cache.localFeed, timestamp: cache.timestamp)))
-        } else {
-          completion(.success(.none))
+      completion(Result {
+        try ManagedCache.find(in: context).map {
+          return CacheFeed(feed: $0.localFeed, timestamp: $0.timestamp)
         }
-      } catch {
-        completion(.failure(error))
-      }
+      })
     }
   }
   
   public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping DeletionCompletion) {
     perform { context in
-      do {
+      completion(Result {
         let managedCache = try ManagedCache.newUniqueInstance(in: context)
         managedCache.timestamp = timestamp
         managedCache.feed = ManagedFeedImage.image(from: feed, in: context)
-        
         try context.save()
-        completion(.success(()))
-      } catch {
-        completion(.failure(error))
-      }
+      })
     }
   }
   
   public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
     perform { context in
-      do {
+      completion(Result {
         try ManagedCache.find(in: context).map(context.delete).map(context.save)
-        completion(.success(()))
-      } catch {
-        completion(.failure(error))
-      }
+      })
     }
   }
   

--- a/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -39,9 +39,9 @@ public final class CoreDataFeedStore: FeedStore {
         managedCache.feed = ManagedFeedImage.image(from: feed, in: context)
         
         try context.save()
-        completion(nil)
+        completion(.success(()))
       } catch {
-        completion(error)
+        completion(.failure(error))
       }
     }
   }
@@ -50,9 +50,9 @@ public final class CoreDataFeedStore: FeedStore {
     perform { context in
       do {
         try ManagedCache.find(in: context).map(context.delete).map(context.save)
-        completion(nil)
+        completion(.success(()))
       } catch {
-        completion(error)
+        completion(.failure(error))
       }
     }
   }

--- a/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -21,9 +21,9 @@ public final class CoreDataFeedStore: FeedStore {
     perform { context in
       do {
         if let cache = try ManagedCache.find(in: context) {
-          completion(.success(.found(feed: cache.localFeed, timestamp: cache.timestamp)))
+          completion(.success(CacheFeed(feed: cache.localFeed, timestamp: cache.timestamp)))
         } else {
-          completion(.success(.empty))
+          completion(.success(.none))
         }
       } catch {
         completion(.failure(error))

--- a/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataHelpers.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataHelpers.swift
@@ -7,7 +7,7 @@
 
 import CoreData
 
-internal extension NSPersistentContainer {
+ extension NSPersistentContainer {
   
   enum LoadingError: Error {
     case modelNotFound

--- a/EssentialFeed/Feed Cache/Infrastructure/CoreData/ManagedCache.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/CoreData/ManagedCache.swift
@@ -8,25 +8,25 @@
 import CoreData
 
 @objc(ManagedCache)
-internal class ManagedCache: NSManagedObject {
-  @NSManaged internal var timestamp: Date
-  @NSManaged internal var feed: NSOrderedSet
+ class ManagedCache: NSManagedObject {
+  @NSManaged  var timestamp: Date
+  @NSManaged  var feed: NSOrderedSet
 }
 
 extension ManagedCache {
   
-  internal static func find(in context: NSManagedObjectContext) throws -> ManagedCache? {
+   static func find(in context: NSManagedObjectContext) throws -> ManagedCache? {
     let request = NSFetchRequest<ManagedCache>(entityName: entity().name!)
     request.returnsObjectsAsFaults = false
     return try context.fetch(request).first
   }
   
-  internal static func newUniqueInstance(in context: NSManagedObjectContext) throws -> ManagedCache {
+   static func newUniqueInstance(in context: NSManagedObjectContext) throws -> ManagedCache {
     try find(in: context).map(context.delete)
     return ManagedCache(context: context)
   }
   
-  internal var localFeed: [LocalFeedImage] {
+   var localFeed: [LocalFeedImage] {
     return feed.compactMap { ($0 as? ManagedFeedImage)?.local }
   }
 }

--- a/EssentialFeed/Feed Cache/Infrastructure/CoreData/ManagedFeedImage.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/CoreData/ManagedFeedImage.swift
@@ -8,17 +8,17 @@
 import CoreData
 
 @objc(ManagedFeedImage)
-internal class ManagedFeedImage: NSManagedObject {
-  @NSManaged internal var id: UUID
-  @NSManaged internal var imageDescription: String?
-  @NSManaged internal var location: String?
-  @NSManaged internal var url: URL
-  @NSManaged internal var cache: ManagedCache
+ class ManagedFeedImage: NSManagedObject {
+  @NSManaged  var id: UUID
+  @NSManaged  var imageDescription: String?
+  @NSManaged  var location: String?
+  @NSManaged  var url: URL
+  @NSManaged  var cache: ManagedCache
 }
  
 extension ManagedFeedImage {
   
-  internal static func image(from localFeed: [LocalFeedImage], in context: NSManagedObjectContext) -> NSOrderedSet {
+   static func image(from localFeed: [LocalFeedImage], in context: NSManagedObjectContext) -> NSOrderedSet {
     return NSOrderedSet(array: localFeed.map { local in
       let managed = ManagedFeedImage(context: context)
       managed.id = local.id
@@ -29,7 +29,7 @@ extension ManagedFeedImage {
     })
   }
   
-  internal var local: LocalFeedImage {
+   var local: LocalFeedImage {
     return LocalFeedImage(id: id, description: imageDescription, location: location, url: url)
   }
 }

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -53,8 +53,8 @@ extension LocalFeedLoader: FeedLoader {
       case let .failure(error):
         completion(.failure(error))
        
-      case let .success(.found(feed, timestamp)) where FeedCachePolicy.validate(timestamp, against: self.currentDate()):
-        completion(.success(feed.toModels()))
+      case let .success(.some(cache)) where FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
+        completion(.success(cache.feed.toModels()))
         
       case .success:
         completion(.success([]))
@@ -73,7 +73,7 @@ extension LocalFeedLoader {
       case .failure:
         self.store.deleteCachedFeed { _ in }
         
-      case let .success(.found(_ , timestamp)) where !FeedCachePolicy.validate(timestamp, against: self.currentDate()):
+      case let .success(.some(cache)) where !FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
         self.store.deleteCachedFeed { _ in }
         
       case .success: break

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -53,10 +53,10 @@ extension LocalFeedLoader: FeedLoader {
       case let .failure(error):
         completion(.failure(error))
        
-      case let .found(feed, timestamp) where FeedCachePolicy.validate(timestamp, against: self.currentDate()):
+      case let .success(.found(feed, timestamp)) where FeedCachePolicy.validate(timestamp, against: self.currentDate()):
         completion(.success(feed.toModels()))
         
-      case .found, .empty:
+      case .success:
         completion(.success([]))
       }
     }
@@ -73,10 +73,10 @@ extension LocalFeedLoader {
       case .failure:
         self.store.deleteCachedFeed { _ in }
         
-      case let .found(_ , timestamp) where !FeedCachePolicy.validate(timestamp, against: self.currentDate()):
+      case let .success(.found(_ , timestamp)) where !FeedCachePolicy.validate(timestamp, against: self.currentDate()):
         self.store.deleteCachedFeed { _ in }
         
-      case .empty, .found: break
+      case .success: break
       }
     }
   }

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -43,7 +43,7 @@ extension LocalFeedLoader {
 }
 
 extension LocalFeedLoader: FeedLoader {
-  public typealias LoadResult = LoadFeedResult
+  public typealias LoadResult = FeedLoader.Result
   
   public func load(completion: @escaping (LoadResult) -> Void) {
     store.retrieve { [weak self] result in

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -19,16 +19,18 @@ public final class LocalFeedLoader {
 }
 
 extension LocalFeedLoader {
-  public typealias SaveResult = Error?
+  public typealias SaveResult = Result<Void,Error>
   
   public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
-    store.deleteCachedFeed { [weak self] error in
+    store.deleteCachedFeed { [weak self] deletionResult in
       guard let self = self else { return }
       
-      if let cacheDeletionError = error {
-        completion(cacheDeletionError)
-      } else {
+      switch deletionResult {
+      case .success:
         self.cache(feed, with: completion)
+      
+      case let .failure(error):
+        completion(.failure(error))
       }
     }
   }

--- a/EssentialFeed/Feed Feature/FeedLoader.swift
+++ b/EssentialFeed/Feed Feature/FeedLoader.swift
@@ -7,10 +7,7 @@
 
 import Foundation
 
-public enum LoadFeedResult {
-  case success([FeedImage])
-  case failure(Error)
-}
+public typealias LoadFeedResult = Result<[FeedImage], Error>
 
 public protocol FeedLoader {
   func load(completion: @escaping (LoadFeedResult) -> Void)

--- a/EssentialFeed/Feed Feature/FeedLoader.swift
+++ b/EssentialFeed/Feed Feature/FeedLoader.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-public typealias LoadFeedResult = Result<[FeedImage], Error>
-
 public protocol FeedLoader {
-  func load(completion: @escaping (LoadFeedResult) -> Void)
+  typealias Result = Swift.Result<[FeedImage], Error>
+  
+  func load(completion: @escaping (Result) -> Void)
 }

--- a/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
+++ b/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
@@ -37,7 +37,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
 
 extension EssentialFeedAPIEndToEndTests {
   
-  private func getFeedResult(file: StaticString = #filePath, line: UInt = #line) -> LoadFeedResult? {
+  private func getFeedResult(file: StaticString = #filePath, line: UInt = #line) -> FeedLoader.Result? {
     let testServerURL = URL(string: "https://essentialdeveloper.com/feed-case-study/test-api/feed")!
     let client = URLSessionHTTPClient(session: URLSession(configuration: .ephemeral))
     let loader = RemoteFeedLoader(url: testServerURL, client: client)
@@ -46,7 +46,7 @@ extension EssentialFeedAPIEndToEndTests {
     
     let exp = expectation(description: "Wait for load completion")
     
-    var receivedResult: LoadFeedResult?
+    var receivedResult: FeedLoader.Result?
     loader.load { result in
       receivedResult = result
       exp.fulfill()

--- a/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
+++ b/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
@@ -66,8 +66,10 @@ class EssentialFeedCacheIntegrationTests: XCTestCase {
   
   private func save(_ feed: [FeedImage], with sut: LocalFeedLoader, file: StaticString = #filePath, line: UInt = #line) {
     let exp = expectation(description: "Wait for save completion")
-    sut.save(feed) { saveError in
-      XCTAssertNil(saveError, "Expected to save feed successfully", file: file, line: line)
+    sut.save(feed) { result in
+      if case let Result.failure(error) = result {
+        XCTAssertNil(error, "Expected to save feed successfully", file: file, line: line)
+      }
       exp.fulfill()
     }
     wait(for: [exp], timeout: 1.0)

--- a/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
@@ -134,9 +134,7 @@ extension LoadFeedFromRemoteUseCaseTests {
       "description": description,
       "location": location,
       "image": imageURL.absoluteString
-    ].reduce(into: [String: Any](), { actual, pair in
-      if let value = pair.value { actual[pair.key] = value }
-    })
+    ].compactMapValues { $0 } 
     
     return (item, json)
   }

--- a/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
@@ -170,13 +170,13 @@ extension LoadFeedFromRemoteUseCaseTests {
 
 private class HTTPClientSpy: HTTPClient {
 
-  private var messages = [(url: URL, completion: (HTTPClientResult) -> Void)]()
+  private var messages = [(url: URL, completion: (HTTPClient.Result) -> Void)]()
   
   var requestedURLs: [URL] {
     return messages.map { $0.url }
   }
   
-  func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void) {
+  func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
     messages.append((url, completion))
   }
   
@@ -190,6 +190,6 @@ private class HTTPClientSpy: HTTPClient {
       statusCode: code,
       httpVersion: nil,
       headerFields: nil)!
-    messages[index].completion(.success(data, response))
+    messages[index].completion(.success((data, response)))
   }
 }

--- a/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -89,7 +89,7 @@ class URLSessionHTTPClientTests: XCTestCase {
     let result = resultFor(data: data, response: response, error: error, file: file, line: line)
     
     switch result {
-    case let .success(data, response):
+    case let .success((data, response)):
       return (data, response)
     default:
       XCTFail("Expected success, got \(result) instead", file: file, line: line)
@@ -109,12 +109,12 @@ class URLSessionHTTPClientTests: XCTestCase {
     }
   }
   
-  private func resultFor(data: Data?, response: URLResponse?, error: Error?, file: StaticString = #filePath, line: UInt = #line) -> HTTPClientResult {
+  private func resultFor(data: Data?, response: URLResponse?, error: Error?, file: StaticString = #filePath, line: UInt = #line) -> HTTPClient.Result {
     URLProtocolStub.stub(data: data, response: response, error: error)
     let sut = makeSUT(file: file, line: line)
     let exp = expectation(description: "Wait for completion")
     
-    var receivedResult: HTTPClientResult!
+    var receivedResult: HTTPClient.Result!
     sut.get(from: anyURL()) { result in
       receivedResult = result
       exp.fulfill()

--- a/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -123,8 +123,8 @@ extension CacheFeedUseCaseTests {
     let exp = expectation(description: "Wait for save completion")
     
     var receivedError: Error?
-    sut.save(uniqueImageFeed().models) { error in
-      receivedError = error
+    sut.save(uniqueImageFeed().models) { result in
+      if case let Result.failure(error) = result { receivedError = error }
       exp.fulfill()
     }
     

--- a/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
@@ -19,6 +19,6 @@ extension FailableDeleteFeedStoreSpecs where Self: XCTestCase {
   func assertThatDeleteHasNoSideEffectsOnDeletionError(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
     deleteCache(from: sut)
 
-    expect(sut, toRetrieve: .empty, file: file, line: line)
+    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
   }
 }

--- a/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
@@ -19,6 +19,6 @@ extension FailableDeleteFeedStoreSpecs where Self: XCTestCase {
   func assertThatDeleteHasNoSideEffectsOnDeletionError(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
     deleteCache(from: sut)
 
-    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+    expect(sut, toRetrieve: .success(.none), file: file, line: line)
   }
 }

--- a/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
@@ -19,6 +19,6 @@ extension FailableInsertFeedStoreSpecs where Self: XCTestCase {
   func assertThatInsertHasNoSideEffectsOnInsertionError(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
     insert((uniqueImageFeed().local, Date()), to: sut)
 
-    expect(sut, toRetrieve: .empty, file: file, line: line)
+    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
   }
 }

--- a/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
@@ -19,6 +19,6 @@ extension FailableInsertFeedStoreSpecs where Self: XCTestCase {
   func assertThatInsertHasNoSideEffectsOnInsertionError(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
     insert((uniqueImageFeed().local, Date()), to: sut)
 
-    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+    expect(sut, toRetrieve: .success(.none), file: file, line: line)
   }
 }

--- a/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -11,11 +11,11 @@ import EssentialFeed
 extension FeedStoreSpecs where Self: XCTestCase {
 
   func assertThatRetrieveDeliversEmptyOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
-    expect(sut, toRetrieve: .empty, file: file, line: line)
+    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
   }
 
   func assertThatRetrieveHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
-    expect(sut, toRetrieveTwice: .empty, file: file, line: line)
+    expect(sut, toRetrieveTwice: .success(.empty), file: file, line: line)
   }
 
   func assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -24,7 +24,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 
     insert((feed, timestamp), to: sut)
 
-    expect(sut, toRetrieve: .found(feed: feed, timestamp: timestamp), file: file, line: line)
+    expect(sut, toRetrieve: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
   }
 
   func assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -33,7 +33,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 
     insert((feed, timestamp), to: sut)
 
-    expect(sut, toRetrieveTwice: .found(feed: feed, timestamp: timestamp), file: file, line: line)
+    expect(sut, toRetrieveTwice: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
   }
 
   func assertThatInsertDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -57,7 +57,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
     let latestTimestamp = Date()
     insert((latestFeed, latestTimestamp), to: sut)
 
-    expect(sut, toRetrieve: .found(feed: latestFeed, timestamp: latestTimestamp), file: file, line: line)
+    expect(sut, toRetrieve: .success(.found(feed: latestFeed, timestamp: latestTimestamp)), file: file, line: line)
   }
 
   func assertThatDeleteDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -69,7 +69,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
   func assertThatDeleteHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
     deleteCache(from: sut)
 
-    expect(sut, toRetrieve: .empty, file: file, line: line)
+    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
   }
 
   func assertThatDeleteDeliversNoErrorOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -85,7 +85,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 
     deleteCache(from: sut)
 
-    expect(sut, toRetrieve: .empty, file: file, line: line)
+    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
   }
 
   func assertThatSideEffectsRunSerially(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -141,21 +141,21 @@ extension FeedStoreSpecs where Self: XCTestCase {
     return deletionError
   }
   
-  func expect(_ sut: FeedStore, toRetrieveTwice expectedResult: RetrieveCachedFeedResult, file: StaticString = #filePath, line: UInt = #line) {
+  func expect(_ sut: FeedStore, toRetrieveTwice expectedResult: FeedStore.RetrievalResult, file: StaticString = #filePath, line: UInt = #line) {
     expect(sut, toRetrieve: expectedResult, file: file, line: line)
     expect(sut, toRetrieve: expectedResult, file: file, line: line)
   }
   
-  func expect(_ sut: FeedStore, toRetrieve expectedResult: RetrieveCachedFeedResult, file: StaticString = #filePath, line: UInt = #line) {
+  func expect(_ sut: FeedStore, toRetrieve expectedResult: FeedStore.RetrievalResult, file: StaticString = #filePath, line: UInt = #line) {
     let exp = expectation(description: "Wait for cache retrieval")
     
     sut.retrieve { retrievedResult in
       switch (expectedResult, retrievedResult) {
-      case (.empty, .empty),
+      case (.success(.empty), .success(.empty)),
            (.failure, .failure):
         break
         
-      case let (.found(expectedFeed, expectedTimestamp), .found(retrievedFeed, retrievedTimestamp)):
+      case let (.success(.found(expectedFeed, expectedTimestamp)), .success(.found(retrievedFeed, retrievedTimestamp))):
         XCTAssertEqual(retrievedFeed, expectedFeed, file: file, line: line)
         XCTAssertEqual(retrievedTimestamp, expectedTimestamp, file: file, line: line)
         

--- a/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -121,8 +121,8 @@ extension FeedStoreSpecs where Self: XCTestCase {
   func insert(_ cache: (feed: [LocalFeedImage], timestamp: Date), to sut: FeedStore) -> Error? {
     let exp = expectation(description: "Wait for cache insertion")
     var insertionError: Error?
-    sut.insert(cache.feed, timestamp: cache.timestamp) { receivedInsertionError in
-      insertionError = receivedInsertionError
+    sut.insert(cache.feed, timestamp: cache.timestamp) { result in
+      if case let Result.failure(error) = result { insertionError = error }
       exp.fulfill()
     }
     wait(for: [exp], timeout: 1.0)
@@ -133,8 +133,8 @@ extension FeedStoreSpecs where Self: XCTestCase {
   func deleteCache(from sut: FeedStore) -> Error? {
     let exp = expectation(description: "Wait for cache deletion")
     var deletionError: Error?
-    sut.deleteCachedFeed { receivedDeletionError in
-      deletionError = receivedDeletionError
+    sut.deleteCachedFeed { result in
+      if case let Result.failure(error) = result { deletionError = error }
       exp.fulfill()
     }
     wait(for: [exp], timeout: 10.0)

--- a/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -11,11 +11,11 @@ import EssentialFeed
 extension FeedStoreSpecs where Self: XCTestCase {
 
   func assertThatRetrieveDeliversEmptyOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
-    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+    expect(sut, toRetrieve: .success(.none), file: file, line: line)
   }
 
   func assertThatRetrieveHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
-    expect(sut, toRetrieveTwice: .success(.empty), file: file, line: line)
+    expect(sut, toRetrieveTwice: .success(.none), file: file, line: line)
   }
 
   func assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -24,7 +24,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 
     insert((feed, timestamp), to: sut)
 
-    expect(sut, toRetrieve: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
+    expect(sut, toRetrieve: .success(CacheFeed(feed: feed, timestamp: timestamp)), file: file, line: line)
   }
 
   func assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -33,7 +33,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 
     insert((feed, timestamp), to: sut)
 
-    expect(sut, toRetrieveTwice: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
+    expect(sut, toRetrieveTwice: .success(CacheFeed(feed: feed, timestamp: timestamp)), file: file, line: line)
   }
 
   func assertThatInsertDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -57,7 +57,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
     let latestTimestamp = Date()
     insert((latestFeed, latestTimestamp), to: sut)
 
-    expect(sut, toRetrieve: .success(.found(feed: latestFeed, timestamp: latestTimestamp)), file: file, line: line)
+    expect(sut, toRetrieve: .success(CacheFeed(feed: latestFeed, timestamp: latestTimestamp)), file: file, line: line)
   }
 
   func assertThatDeleteDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -69,7 +69,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
   func assertThatDeleteHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
     deleteCache(from: sut)
 
-    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+    expect(sut, toRetrieve: .success(.none), file: file, line: line)
   }
 
   func assertThatDeleteDeliversNoErrorOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -85,7 +85,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 
     deleteCache(from: sut)
 
-    expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+    expect(sut, toRetrieve: .success(.none), file: file, line: line)
   }
 
   func assertThatSideEffectsRunSerially(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -151,13 +151,13 @@ extension FeedStoreSpecs where Self: XCTestCase {
     
     sut.retrieve { retrievedResult in
       switch (expectedResult, retrievedResult) {
-      case (.success(.empty), .success(.empty)),
+      case (.success(.none), .success(.none)),
            (.failure, .failure):
         break
         
-      case let (.success(.found(expectedFeed, expectedTimestamp)), .success(.found(retrievedFeed, retrievedTimestamp))):
-        XCTAssertEqual(retrievedFeed, expectedFeed, file: file, line: line)
-        XCTAssertEqual(retrievedTimestamp, expectedTimestamp, file: file, line: line)
+      case let (.success(.some(expected)), .success(.some(retrieved))):
+        XCTAssertEqual(retrieved.feed, expected.feed, file: file, line: line)
+        XCTAssertEqual(retrieved.timestamp, expected.timestamp, file: file, line: line)
         
       default:
         XCTFail("Expected to retrieve \(expectedResult), got \(retrievedResult) instead", file: file, line: line)

--- a/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -58,10 +58,10 @@ class FeedStoreSpy: FeedStore {
   }
   
   func completeRetrievalWithEmtyCache(at index: Int = 0) {
-    retrievalCompletions[index](.success(.empty))
+    retrievalCompletions[index](.success(.none))
   }
   
   func completeRetrieval(with feed: [LocalFeedImage], timestamp: Date, at index: Int = 0) {
-    retrievalCompletions[index](.success(.found(feed: feed, timestamp: timestamp)))
+    retrievalCompletions[index](.success(CacheFeed(feed: feed, timestamp: timestamp)))
   }
 }

--- a/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -28,11 +28,11 @@ class FeedStoreSpy: FeedStore {
   }
   
   func completeDeletion(with error: Error, at index: Int = 0) {
-    deletionCompletions[index](error)
+    deletionCompletions[index](.failure(error))
   }
   
   func completeDeletionSuccessfully(at index: Int = 0) {
-    deletionCompletions[index](nil)
+    deletionCompletions[index](.success(()))
   }
   
   func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping DeletionCompletion) {
@@ -41,11 +41,11 @@ class FeedStoreSpy: FeedStore {
   }
   
   func completeInsertion(with error: Error, at index: Int = 0) {
-    insertionCompletions[index](error)
+    insertionCompletions[index](.failure(error))
   }
   
   func completeInsertionSuccessfully(at index: Int = 0) {
-    insertionCompletions[index](nil)
+    insertionCompletions[index](.success(()))
   }
   
   func retrieve(completion: @escaping RetrievalCompletion) {

--- a/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -58,10 +58,10 @@ class FeedStoreSpy: FeedStore {
   }
   
   func completeRetrievalWithEmtyCache(at index: Int = 0) {
-    retrievalCompletions[index](.empty)
+    retrievalCompletions[index](.success(.empty))
   }
   
   func completeRetrieval(with feed: [LocalFeedImage], timestamp: Date, at index: Int = 0) {
-    retrievalCompletions[index](.found(feed: feed, timestamp: timestamp))
+    retrievalCompletions[index](.success(.found(feed: feed, timestamp: timestamp)))
   }
 }


### PR DESCRIPTION
Migrate to Swift 5 and refactor the code to use the standard `Swift.Result` type.