### PR TITLE
Fix potential crash on `didEndDisplayingCell`

### DIFF
--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -68,6 +68,20 @@ final class FeedUIIntegrationTests: XCTestCase {
     assertThat(sut, isRendering: [image0, image1, image2, image3])
   }
   
+  func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+    let image0 = makeImage()
+    let image1 = makeImage()
+    let (sut, loader) = makeSUT()
+    
+    sut.loadViewIfNeeded()
+    loader.completeFeedLoading(with: [image0, image1], at: 0)
+    assertThat(sut, isRendering: [image0, image1])
+    
+    sut.simulateUserInitiatedFeedReload()
+    loader.completeFeedLoading(with: [], at: 1)
+    assertThat(sut, isRendering: [])
+  }
+  
   func test_loadFeedCompletion_doestNotAlterCurrentRenderingStateOnError() {
     let image0 = makeImage()
     let (sut, loader) = makeSUT()

--- a/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
@@ -13,6 +13,9 @@ extension FeedUIIntegrationTests {
   
   func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage],
                           file: StaticString = #filePath, line: UInt = #line) {
+    sut.tableView.layoutIfNeeded()
+    RunLoop.main.run(until: Date())
+    
     guard sut.numberOfRenderedFeedImageViews() == feed.count else {
       return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
     }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -15,6 +15,8 @@ public protocol FeedViewControllerDelegate {
 public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching, FeedLoadingView, FeedErrorView {
   @IBOutlet public private(set) var errorView: ErrorView?
   
+  private var loadingControllers = [IndexPath: FeedImageCellController]()
+  
   private var tableModel = [FeedImageCellController]() {
     didSet { tableView.reloadData() }
   }
@@ -38,6 +40,7 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
   }
   
   public func display(_ cellControllers: [FeedImageCellController]) {
+    loadingControllers = [:]
     tableModel = cellControllers
   }
   
@@ -72,10 +75,13 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
   }
   
   private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-    return tableModel[indexPath.row]
+    let controller = tableModel[indexPath.row]
+    loadingControllers[indexPath] = controller
+    return controller
   }
   
   private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-    cellController(forRowAt: indexPath).cancelLoad()
+    loadingControllers[indexPath]?.cancelLoad()
+    loadingControllers[indexPath] = nil
   }
 }


### PR DESCRIPTION
When updating the table model and reloading the table, UIKit calls `didEndDisplayingCell` for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behavior going further.